### PR TITLE
Updating Dockerfiles for api and batcher

### DIFF
--- a/Dockerfile-build-linux-api
+++ b/Dockerfile-build-linux-api
@@ -1,9 +1,18 @@
-FROM golang:1.11
+FROM golang:1.12.4-alpine3.9 as builder
+
+RUN apk add --update --no-cache libc6-compat \
+        git \
+        ca-certificates \
+        build-base
 
 RUN mkdir /topaz 
 COPY . /topaz/
 
 WORKDIR /topaz/api
-RUN go build -mod=vendor -o ../topaz-api .
+RUN go build -mod=vendor -ldflags "-linkmode external -extldflags -static" -tags netgo -installsuffix netgo -a -o ../topaz-api .
 
 WORKDIR /topaz
+
+FROM alpine:3.9.3
+COPY --from=builder /topaz/topaz-api .
+CMD ["./topaz-api"]  

--- a/Dockerfile-build-linux-batch
+++ b/Dockerfile-build-linux-batch
@@ -1,9 +1,28 @@
-FROM golang:1.11
+FROM golang:1.12.4-alpine3.9 as builder
+
+RUN apk add --update --no-cache libc6-compat \
+        git \
+        ca-certificates \
+        build-base
 
 RUN mkdir /topaz 
 COPY . /topaz/
 
-WORKDIR /topaz/batch
-RUN go build -o ../topaz-batch .
+WORKDIR /
 
-WORKDIR /topaz
+RUN go get github.com/ethereum/go-ethereum
+
+RUN cd /topaz && go get && \
+    cp -r "${GOPATH}/src/github.com/ethereum/go-ethereum/crypto/secp256k1/libsecp256k1" \
+          "vendor/github.com/ethereum/go-ethereum/crypto/secp256k1/"
+
+WORKDIR /topaz/batch
+
+RUN go build -mod=vendor -ldflags "-linkmode external -extldflags -static" -tags netgo -installsuffix netgo -a -o ../topaz-batch .
+
+WORKDIR /topaz/batch
+
+FROM alpine:3.9.3
+COPY --from=builder /topaz/topaz-batch .
+RUN apk add --update --no-cache libc6-compat
+CMD ["./topaz-batch"]  


### PR DESCRIPTION
Updating the Dockerfiles to build static binaries that are placed in downstream containers for deployment to ECS to keep sizes small since ECR charges based on space.