### PR TITLE
If no "currently_batching" key in redis exists, then just assume no b…

### DIFF
--- a/batch/main.go
+++ b/batch/main.go
@@ -27,12 +27,7 @@ var currentlyBatching = "currently_batching"
 var afterBatchSleep = 1000
 
 func safeBatch() bool {
-	isBatching, err := redis.GetBool(currentlyBatching)
-
-	if err != nil {
-		fmt.Println("error getting batch status from redis:", err)
-		return false
-	}
+	isBatching, _ := redis.GetBool(currentlyBatching)
 
 	if isBatching == true {
 		fmt.Println("batch process is already executing")


### PR DESCRIPTION
…atch is happening and do it