### PR TITLE
Add ca-certificates package to each final container at build time

### DIFF
--- a/Dockerfile-build-linux-api
+++ b/Dockerfile-build-linux-api
@@ -16,4 +16,5 @@ WORKDIR /topaz
 
 FROM alpine:3.9.3
 COPY --from=builder /topaz/topaz-api .
-CMD ["./topaz-api"]  
+RUN apk add --update --no-cache libc6-compat ca-certificates
+CMD ["./topaz-api"]

--- a/Dockerfile-build-linux-batch
+++ b/Dockerfile-build-linux-batch
@@ -24,5 +24,5 @@ WORKDIR /topaz/batch
 
 FROM alpine:3.9.3
 COPY --from=builder /topaz/topaz-batch .
-RUN apk add --update --no-cache libc6-compat
+RUN apk add --update --no-cache libc6-compat ca-certificates
 CMD ["./topaz-batch"]  


### PR DESCRIPTION
To resolve the error from Sendgrid `Post https://api.sendgrid.com/v3/mail/send: x509: certificate signed by unknown authority`